### PR TITLE
Unpin dependencies version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pchain-sdk"
-version = "0.4.2"
+version = "0.5.0"
 authors = ["ParallelChain Lab <info@parallelchain.io>"]
 edition = "2021"
 description = "The ParallelChain Smart Contract Development Kit (SDK)."
@@ -13,5 +13,5 @@ doctest = false
 
 [dependencies]
 borsh = "=0.10.2"
-pchain-types = "=0.4.3"
-pchain-sdk-macros = "=0.4.2"
+pchain-types = { git = "https://github.com/parallelchain-io/pchain-types-rust", branch = "protocol_v0.5" }
+pchain-sdk-macros = { path = "./macros" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pchain-sdk"
-version = "0.5.0"
+version = "0.4.2"
 authors = ["ParallelChain Lab <info@parallelchain.io>"]
 edition = "2021"
 description = "The ParallelChain Smart Contract Development Kit (SDK)."
@@ -13,5 +13,5 @@ doctest = false
 
 [dependencies]
 borsh = "=0.10.2"
-pchain-types = { git = "https://github.com/parallelchain-io/pchain-types-rust", branch = "protocol_v0.5" }
-pchain-sdk-macros = { path = "./macros" }
+pchain-types = "0.4.3"
+pchain-sdk-macros = "0.4.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,6 @@ repository = "https://github.com/parallelchain-io/parallelchain-sdk"
 doctest = false
 
 [dependencies]
-borsh = "=0.10.2"
+borsh = "0.10.2"
 pchain-types = "0.4.3"
 pchain-sdk-macros = "0.4.2"

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pchain-sdk-macros"
-version = "0.4.2"
+version = "0.5.0"
 authors = ["ParallelChain Lab <info@parallelchain.io>"]
 edition = "2021"
 description = "parallelchain-sdk: macro implementation for SDK"
@@ -17,5 +17,5 @@ snakecase = "0.1"
 syn = {version = "1.0", features = ["fold", "full"]}
 quote = "1.0"
 proc-macro2 = "1.0"
-pchain-types = "=0.4.3"
+pchain-types = { git = "https://github.com/parallelchain-io/pchain-types-rust", branch = "protocol_v0.5" }
 base64url = "0.1.0"

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pchain-sdk-macros"
-version = "0.5.0"
+version = "0.4.2"
 authors = ["ParallelChain Lab <info@parallelchain.io>"]
 edition = "2021"
 description = "parallelchain-sdk: macro implementation for SDK"
@@ -17,5 +17,5 @@ snakecase = "0.1"
 syn = {version = "1.0", features = ["fold", "full"]}
 quote = "1.0"
 proc-macro2 = "1.0"
-pchain-types = { git = "https://github.com/parallelchain-io/pchain-types-rust", branch = "protocol_v0.5" }
+pchain-types = "0.4.3"
 base64url = "0.1.0"


### PR DESCRIPTION
1. Unpin versions of dependencies: `pchain_types`, `borsh`, and `pchain-sdk-macros`